### PR TITLE
Add Milestone 0 scaffold: Akka HTTP + MongoDB dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.idea/
+.bsp/
+.metals/
+.metals.sbt/
+.vscode/
+.target/
+project/project/
+project/target/
+target/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@ Lichess Tournament Director
 
 **Goal:** Create a system for automatically managing long-running Swiss tournaments on Lichess.org. 
 
+## Development
+
+### Start MongoDB replica set
+
+```bash
+docker compose up -d
+```
+
+### Run the service
+
+```bash
+sbt run
+```
+
+The health endpoint should respond with `ok`:
+
+```bash
+curl http://localhost:8080/health
+```
+
 References:
 * [Lichess Feedback - Clocks start automatically in Swiss Tournament?!](https://lichess.org/forum/redirect/post/L9boi7eP)
 * [Lichess Feedback - starting timer should be removed#3](https://lichess.org/forum/redirect/post/AvLmQzeD)

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,19 @@
+ThisBuild / scalaVersion := "3.3.1"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "litd",
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-actor-typed" % "2.8.5",
+      "com.typesafe.akka" %% "akka-http" % "10.5.2",
+      "com.typesafe.akka" %% "akka-stream" % "2.8.5",
+      "com.typesafe" % "config" % "1.4.2",
+      "de.heikoseeberger" %% "akka-http-circe" % "1.39.2",
+      "io.circe" %% "circe-core" % "0.14.6",
+      "io.circe" %% "circe-generic" % "0.14.6",
+      "io.circe" %% "circe-parser" % "0.14.6",
+      "org.mongodb.scala" %% "mongo-scala-driver" % "4.11.0",
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test
+    )
+  )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  mongo:
+    image: mongo:6.0
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27017:27017"
+    volumes:
+      - ./docker/mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro

--- a/docker/mongo-init.js
+++ b/docker/mongo-init.js
@@ -1,0 +1,6 @@
+rs.initiate({
+  _id: "rs0",
+  members: [
+    { _id: 0, host: "mongo:27017" }
+  ]
+});

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,11 @@
+litd {
+  http {
+    host = "0.0.0.0"
+    port = 8080
+  }
+
+  mongodb {
+    uri = "mongodb://localhost:27017/?replicaSet=rs0"
+    database = "litd"
+  }
+}

--- a/src/main/scala/litd/Main.scala
+++ b/src/main/scala/litd/Main.scala
@@ -1,0 +1,66 @@
+package litd
+
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.*
+import com.typesafe.config.{Config, ConfigFactory}
+import org.mongodb.scala.MongoClient
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+final case class HttpConfig(host: String, port: Int)
+final case class MongoConfig(uri: String, database: String)
+final case class AppConfig(http: HttpConfig, mongodb: MongoConfig)
+
+object AppConfigLoader {
+  def load(config: Config = ConfigFactory.load()): AppConfig = {
+    val httpConfig = config.getConfig("litd.http")
+    val mongoConfig = config.getConfig("litd.mongodb")
+    AppConfig(
+      http = HttpConfig(
+        host = httpConfig.getString("host"),
+        port = httpConfig.getInt("port")
+      ),
+      mongodb = MongoConfig(
+        uri = mongoConfig.getString("uri"),
+        database = mongoConfig.getString("database")
+      )
+    )
+  }
+}
+
+object MongoClientFactory {
+  def create(mongoConfig: MongoConfig): MongoClient = MongoClient(mongoConfig.uri)
+}
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem[Nothing] = ActorSystem(Behaviors.empty, "litd")
+    implicit val ec: ExecutionContext = system.executionContext
+
+    val appConfig = AppConfigLoader.load()
+    val mongoClient = MongoClientFactory.create(appConfig.mongodb)
+
+    // GET /health -> "ok"
+    val routes = path("health") {
+      get {
+        complete(StatusCodes.OK -> "ok")
+      }
+    }
+
+    Http()
+      .newServerAt(appConfig.http.host, appConfig.http.port)
+      .bind(routes)
+      .onComplete {
+        case Success(binding) =>
+          system.log.info("Server running at {}", binding.localAddress)
+        case Failure(ex) =>
+          system.log.error("Failed to bind HTTP endpoint", ex)
+          mongoClient.close()
+          system.terminate()
+      }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an initial Milestone 0 scaffold to start implementing the LiTD service with Scala 3, Akka HTTP and MongoDB as specified.
- Give a minimal runnable development flow and a simple health endpoint so further features can be integrated and tested incrementally.

### Description
- Add `build.sbt` and `project/build.properties` with Scala 3 and core dependencies for Akka, Circe, and the MongoDB Scala driver so the project can be built with `sbt`.
- Implement `src/main/scala/litd/Main.scala` which loads configuration, creates a `MongoClient`, and starts an Akka HTTP server exposing `GET /health` that returns `ok`.
- Add `src/main/resources/application.conf` with default `litd.http` and `litd.mongodb` configuration values and add a Docker Compose `docker-compose.yml` plus `docker/mongo-init.js` to bring up a local MongoDB replica set for development.
- Add project housekeeping files including `.gitignore` and update `README.md` with development instructions for `docker compose up -d`, `sbt run`, and the health check `curl` command.

### Testing
- Ran `sbt compile` which could not be executed because `sbt` is not installed in the current environment (failure).
- Ran `sbt test` which could not be executed because `sbt` is not installed in the current environment (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698978a8a8f8832ebcd506d0094d3c83)